### PR TITLE
Introduce a configurable Token Endpoint

### DIFF
--- a/configs.php
+++ b/configs.php
@@ -2,24 +2,25 @@
 
 return (object) array(
 	// First some settings for the site
-	'siteUrl' => 'https://example.com/',			// the URL for your site - note trailing slash
-	'timezone' => 'Europe/London',					// http://php.net/manual/en/timezones.php
-	'mediaPoint' => 'https://media.org/endpoint',	// Micropub Media Endpoint
+	'siteUrl' => 'https://example.com/',					// the URL for your site - note trailing slash
+	'timezone' => 'Europe/London',							// http://php.net/manual/en/timezones.php
+	'mediaPoint' => 'https://media.org/endpoint',			// Micropub Media Endpoint
+	'tokenPoint' => 'https://tokens.indieauth.com/token',	// IndieAuth Token Endpoint
 	
 	// Config Block for Twitter
-	'twitterName' => 'poopyCakes',					// your twitter account name, don't use the @
-	'twAPIkey' => 'WomtvR2YoT',						// Create an app on dev.twitter.com for your account.
-	'twAPIsecret' => 'NILIDJXg1e',					// APIkey & APIsecret are the APP's key & Secret
-	'twUserKey' => 'ILs4jUS7a6',					// UserKey & User Secret are under 'Your access token'
-	'twUserSecret' => 'NYbGUfuNUh',					// Generate those on dev.twitter.com
+	'twitterName' => 'poopyCakes',							// your twitter account name, don't use the @
+	'twAPIkey' => 'WomtvR2YoT',								// Create an app on dev.twitter.com for your account.
+	'twAPIsecret' => 'NILIDJXg1e',							// APIkey & APIsecret are the APP's key & Secret
+	'twUserKey' => 'ILs4jUS7a6',							// UserKey & User Secret are under 'Your access token'
+	'twUserSecret' => 'NYbGUfuNUh',							// Generate those on dev.twitter.com
 
 	// Config Block for Mastodon
-	'mastodonInstance' => 'servername.ext',			// your Mastodon Instance
-	'mastodonToken' => 'uWo42Bca91',				// get an auth code using Mastodon docs
+	'mastodonInstance' => 'servername.ext',					// your Mastodon Instance
+	'mastodonToken' => 'uWo42Bca91',						// get an auth code using Mastodon docs
 
 	// Config for micro.blog
-	'pingMicro' => True, 							// Set to False (boolean) if you don't use micro.blog
-	'siteFeed' => 'https://example.com/atom.xml',	// Set to your site's RSS/Atom Feed to notify micro.blog
+	'pingMicro' => True, 									// Set to False (boolean) if you don't use micro.blog
+	'siteFeed' => 'https://example.com/atom.xml',			// Set to your site's RSS/Atom Feed to notify micro.blog
 
 	// Config for Weather. If you do want weather feature, set to true 
     'weatherToggle' => false,


### PR DESCRIPTION
Changes to the configs file:
* Add a new configuration called `tokenPoint` below `mediaPoint`.

Changes to nanopub, in source order:
* Give the `indieAuth` function access to the `$configs` variable.
* State that we accept JSON from the server, this is necessary to make [`https://tokens.indieauth.com/`](https://tokens.indieauth.com/) send modern responses.
* Query the new `tokenPoint` rather than a hard-coded one.
* Curl can return `false`, so force it to a string.
* Try to JSON decode it. Per the IndieAuth specification, token endpoints return JSON.
* If decoding did not give us an array, or something else went wrong, fall back to `parse_str` because the server may be old and have given us a form-encoded response body.
* Check the existence of `scope` in the response array before doing `explode`.
* If the response array contains an `error` key, exit early.
* Check the existence of `me` in the response array before comparing it to the configuration.