### PR TITLE
Introduce configurable storage folders

### DIFF
--- a/configs.php
+++ b/configs.php
@@ -6,6 +6,8 @@ return (object) array(
 	'timezone' => 'Europe/London',							// http://php.net/manual/en/timezones.php
 	'mediaPoint' => 'https://media.org/endpoint',			// Micropub Media Endpoint
 	'tokenPoint' => 'https://tokens.indieauth.com/token',	// IndieAuth Token Endpoint
+	'storageFolder' => '../content',						// the folder to store the posts in
+	'trashFolder' => '../trash',							// the folder to move removed posts into
 	
 	// Config Block for Twitter
 	'twitterName' => 'poopyCakes',							// your twitter account name, don't use the @

--- a/nanopub.php
+++ b/nanopub.php
@@ -248,6 +248,11 @@ function write_file($frontmatter, $content, $fn)
         $frontFinal = json_encode($frontmatter, 32 | 64 | 128 | 256) . "\n\n";
     }
 
+    $dir = pathinfo($fn, PATHINFO_DIRNAME);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
     file_put_contents($fn, $frontFinal);
     file_put_contents($fn, $content, FILE_APPEND | LOCK_EX);
 }
@@ -346,7 +351,7 @@ if (isset($_GET['q']) && $_GET['q'] == 'source') {
             $repl = "";
             $srcUri = preg_replace($pattern, $repl, $subj);
             $srcUri = rtrim($srcUri, "/");
-            if ($textFile = file_get_contents("../content/$srcUri.md")) {
+            if ($textFile = file_get_contents($configs->storageFolder . "/$srcUri.md")) {
 
                 //send file for decoding
                 $jsonArray = decode_input($textFile, $mfArray, true);
@@ -393,13 +398,16 @@ if (!empty($data)) {
                 $srcUri = rtrim($srcUri, "/");
                 // First delete if asked to
                 if ($action == "delete") {
-                    rename("../content/$srcUri.md", "../trash/$srcUri.md");
+                    if (!is_dir($configs->trashFolder)) {
+                        mkdir($configs->trashFolder, 0777, true);
+                    }
+                    rename($configs->storageFolder . "/$srcUri.md", $configs->trashFolder . "/$srcUri.md");
                     header("HTTP/1.1 204 No Content");
                     exit;
                 }
                 // then an undelete
                 if ($action == "undelete") {
-                    rename("../trash/$srcUri.md", "../content/$srcUri.md");
+                    rename($configs->trashFolder . "/$srcUri.md", $configs->storageFolder . "/$srcUri.md");
                     header("HTTP/1.1 201 Created");
                     header("Location: ".$siteUrl.$srcUri);
                     exit;
@@ -407,7 +415,7 @@ if (!empty($data)) {
                 // Update can be one of a number of different actions
                 if ($action == "update") {
                     // Updating, so need to read the existing file
-                    if ($textFile = file_get_contents("../content/$srcUri.md")) {
+                    if ($textFile = file_get_contents($configs->storageFolder . "/$srcUri.md")) {
                         //send file for decoding
                         $jsonArray = decode_input($textFile, $mfArray, false);
 
@@ -469,7 +477,7 @@ if (!empty($data)) {
 
                         $content = $jsonArray['content'];
                         unset($jsonArray['content']);
-                        $fn = "../content/".$srcUri.".md";
+                        $fn = $configs->storageFolder . "/$srcUri.md";
                         write_file($jsonArray, $content, $fn);
                         header("HTTP/1.1 200 OK");
                         echo json_encode($jsonArray, 128);
@@ -650,25 +658,25 @@ if (!empty($data)) {
             if (!empty($frontmatter['title'])) { 
                 // File locations are specific to my site for now.
                 if (!empty($frontmatter['link'])) {
-                    $fn = "../content/link/" . $frontmatter['slug'] . ".md";
+                    $fn = $configs->storageFolder . "/link/" . $frontmatter['slug'] . ".md";
                     $canonical = $configs->siteUrl . "link/" . $frontmatter['slug'];
                     $synText = $frontmatter['title'];
                 } else {
-                    $fn = "../content/article/" . $frontmatter['slug'] . ".md";
+                    $fn = $configs->storageFolder . "/article/" . $frontmatter['slug'] . ".md";
                     $canonical = $configs->siteUrl . "article/" . $frontmatter['slug'];
                     $synText = $frontmatter['title'];
                 }
             } else { 
                 if (!empty($frontmatter['repost_of'])) {
-                    $fn = "../content/like/" . $frontmatter['slug'] . ".md";
+                    $fn = $configs->storageFolder . "/like/" . $frontmatter['slug'] . ".md";
                     $canonical = $configs->siteUrl . "like/" . $frontmatter['slug'];
                     $synText = $content;
                 } elseif (!empty($frontmatter['like_of'])) {
-                    $fn = "../content/like/" . $frontmatter['slug'] . ".md";
+                    $fn = $configs->storageFolder . "/like/" . $frontmatter['slug'] . ".md";
                     $canonical = $configs->siteUrl . "like/" . $frontmatter['slug'];
                     $synText = $content;
                 } else {
-                    $fn = "../content/micro/" . $frontmatter['slug'] . ".md";
+                    $fn = $configs->storageFolder . "/micro/" . $frontmatter['slug'] . ".md";
                     $canonical = $configs->siteUrl . "micro/" . $frontmatter['slug'];
                     $synText = $content;
                 }


### PR DESCRIPTION
This has come up a number of times in the chat, but I am guessing it is a pretty low priority. Per good [selfdogfooding](https://indieweb.org/selfdogfood), you shouldn’t be implementing features just for other people. On the other hand, I get to implement this because I want it to be a thing. And send you a PR. So here it goes!

1. Add two new configurations: `storageFolder` and `trashFolder`. These contain the paths to their respective folders.
2. Expands the `write_file()` function to check the directory it wants to write to exists, else try to create it. This way subfolders for the different post types will be created automatically.

Just to make sure people aren’t missing out on the trash folder, when a delete action is received it will also make sure that the folder exists and otherwise try to create it. (Lines 401 to 403.) This is somewhat defensive programming (although I still do not check if it was created successfully or the `rename()` was successful) and could be removed if you prefer more [offensive programming](https://en.wikipedia.org/wiki/Defensive_programming#Offensive_programming).